### PR TITLE
server: add `localAddress` fallback for node v0.8

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -213,7 +213,7 @@ function proxySocket(socket, req) {
            .on('connect', function() {
              connected = true;
              if (socket.writable) {
-              var localbytes = ipbytes(dstSock.localAddress),
+              var localbytes = ipbytes(dstSock.localAddress || '127.0.0.1'),
                   len = localbytes.length,
                   bufrep = new Buffer(6 + len),
                   p = 4;


### PR DESCRIPTION
I'm not sure if this is 100% the correct way to fix this, but it does make basic usage scripts work now, whereas before they'd fail with:

```
/Users/nrajlich/node_modules/socksv5/lib/server.js:217
                  len = localbytes.length,
                                  ^
TypeError: Cannot read property 'length' of undefined
    at Socket.dns.lookup.socket.dstSock (/Users/nrajlich/node_modules/socksv5/lib/server.js:217:35)
    at Socket.EventEmitter.emit (events.js:93:17)
    at Object.afterConnect [as oncomplete] (net.js:752:10)
```

(I know that v0.8 is getting pretty old at this point, but I try to keep compatibility when it's a one-line fix like this)

:beers: 