### PR TITLE
store data through connection

### DIFF
--- a/lib/auth/UserPassword.js
+++ b/lib/auth/UserPassword.js
@@ -129,7 +129,7 @@ module.exports = function UserPasswordAuthHandlers() {
                       stream.write(BUF_FAILURE);
                     cb(success);
                   }
-                });
+                }, stream);
                 return;
               }
             break;

--- a/lib/server.js
+++ b/lib/server.js
@@ -127,7 +127,7 @@ Server.prototype._onConnection = function(socket) {
     }
 
     if (self._events.connection) {
-      self.emit('connection', reqInfo, accept, deny);
+      self.emit('connection', reqInfo, accept, deny, socket);
       return;
     }
 
@@ -138,10 +138,17 @@ Server.prototype._onConnection = function(socket) {
     if (socket.dstSock && socket.dstSock.writable)
       socket.dstSock.end();
     socket.dstSock = undefined;
+    self.emit('clientClose', socket);
+  }
+
+  function onEnd() {
+      if (socket.dstSock && socket.dstSock.writable)
+          socket.dstSock.end();
+      socket.dstSock = undefined;
   }
 
   socket.on('error', onErrorNoop)
-        .on('end', onClose)
+        .on('end', onEnd)
         .on('close', onClose);
 };
 


### PR DESCRIPTION
I would like to implement bandwidth monitoring as well as request log. 
I need to have some object where I can store current user between different events.
How would you suggest to do it? I think passing socket object to connection event is not best idea - should I create custom extra-data object? 

Here is the sample of what I am trying to do:

```
var socks = require('socksv5');

var srv = socks.createServer(function(info, accept, deny, socket) {
  accept();

  // log request
  console.log(socket.authUser + " requested: ");
  console.log(info);
});

srv.listen(1080, '0.0.0.0', function() {
  console.log('SOCKS server listening on port 1080');
});

srv.useAuth(socks.auth.UserPassword(function(user, password, cb, socket) {
  cb(user === 'user' && password === 'xxx');
  socket.authUser = "user"; // save user in the socket object
}));

srv.on("clientClose", function(socket) {
  console.log("Client");
  console.log("user:" + socket.authUser); // get user from socket object

  // collect data transferred to specific user
  console.log("read:" + socket.bytesRead);
  console.log("written:" + socket.bytesWritten);
}); 
```
