### PR TITLE
Agent: handle socket errors while connecting to the proxy

### DIFF
--- a/lib/Agents.js
+++ b/lib/Agents.js
@@ -194,6 +194,8 @@ Agent.prototype.addRequest = function(req, options) {
     var client = this.createSocket(req, options);
     client.once('connect', function(s) {
       req.onSocket(s._tlssock || s);
+    }).on('error', function(e) {
+      req.onSocket(client._sock);
     });
   } else {
     debug('wait for socket');
@@ -292,6 +294,8 @@ Agent.prototype.removeSocket = function(s, options) {
     var client = this.createSocket(req, options);
     client.once('connect', function(s) {
       (s._tlssock || s).emit('free');
+    }).on('error', function(e) {
+      req.onSocket(client._sock);
     });
   }
 };


### PR DESCRIPTION
Passing client socket to the request on error allows it to be handled (vs aborting the process because of the unhandled exception)
