### PR TITLE
Added feature to server.js

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -20,6 +20,8 @@ var BUF_AUTH_NO_ACCEPT = new Buffer([0x05, 0xFF]),
     BUF_REP_DISALLOW = new Buffer([0x05, REP.DISALLOW]),
     BUF_REP_CMDUNSUPP = new Buffer([0x05, REP.CMDUNSUPP]);
 
+var Client = require('./client.js');
+	
 function Server(options, listener) {
   if (!(this instanceof Server))
     return new Server(options, listener);
@@ -185,8 +187,17 @@ Server.prototype.unref = function() {
 };
 
 
+// MOD	
+var proxOptions;
+
 exports.Server = Server;
-exports.createServer = function(opts, listener) {
+exports.createServer = function(opts, listener, hlpOpts) {
+	if(hlpOpts) {
+		proxOptions = hlpOpts;
+		if(typeof hlpOpts.enabled === 'undefined') {
+			proxOptions.enabled = true;
+		}
+	}
   return new Server(opts, listener);
 };
 
@@ -205,34 +216,62 @@ function proxySocket(socket, req) {
         handleProxyError(socket, err);
     }
 
-    var dstSock = new net.Socket(),
+    var dstSock,
         connected = false;
+	
+	/* 
+	Beginning mod
+	*/
+	
+	var onConnect = function(proxSock) {
+	   if(proxOptions && proxOptions.enabled) {
+		 dstSock = proxSock;
+		 dstSock.setKeepAlive(false);		   
+	   }
+	   connected = true;
+	   if (socket.writable) {
+	    var localbytes = ipbytes(dstSock.localAddress),
+	  	  len = localbytes.length,
+	  	  bufrep = new Buffer(6 + len),
+	  	  p = 4;
+	    bufrep[0] = 0x05;
+	    bufrep[1] = REP.SUCCESS;
+	    bufrep[2] = 0x00;
+	    bufrep[3] = (len === 4 ? ATYP.IPv4 : ATYP.IPv6);
+	    for (var i = 0; i < len; ++i, ++p)
+	  	bufrep[p] = localbytes[i];
+	    bufrep.writeUInt16BE(dstSock.localPort, p, true);
+	    socket.write(bufrep);
+	    socket.pipe(dstSock).pipe(socket);
+	    socket.resume();
+	   } else if (dstSock.writable)
+	    dstSock.end();
+    }
+	
+	if(proxOptions && proxOptions.enabled) {
+		var client = Client.connect({
+		  host: dstIP,
+		  port: req.dstPort,
+		  proxyHost: proxOptions.proxyHost,
+		  proxyPort: proxOptions.proxyPort,
+		  auths: proxOptions.auths
+		})
+		client.on('error', onError)
+				// explicitly pass 'socket' object
+				.on('connect', function(proxSock) {
+				  onConnect(proxSock);
+				})
+		socket.dstSock = dstSock;
+	} else {
+		dstSock = new net.Socket();
+		dstSock.setKeepAlive(false);
+		dstSock.on('error', onError)
+			   .on('connect', onConnect)
+			   .connect(req.dstPort, dstIP);
+		socket.dstSock = dstSock;
+	}
 
-    dstSock.setKeepAlive(false);
-    dstSock.on('error', onError)
-           .on('connect', function() {
-             connected = true;
-             if (socket.writable) {
-              var localbytes = ipbytes(dstSock.localAddress || '127.0.0.1'),
-                  len = localbytes.length,
-                  bufrep = new Buffer(6 + len),
-                  p = 4;
-              bufrep[0] = 0x05;
-              bufrep[1] = REP.SUCCESS;
-              bufrep[2] = 0x00;
-              bufrep[3] = (len === 4 ? ATYP.IPv4 : ATYP.IPv6);
-              for (var i = 0; i < len; ++i, ++p)
-                bufrep[p] = localbytes[i];
-              bufrep.writeUInt16BE(dstSock.localPort, p, true);
-
-              socket.write(bufrep);
-              socket.pipe(dstSock).pipe(socket);
-              socket.resume();
-             } else if (dstSock.writable)
-              dstSock.end();
-           })
-           .connect(req.dstPort, dstIP);
-    socket.dstSock = dstSock;
+    
   });
 }
 


### PR DESCRIPTION
### Simple socks chaining

Now you able to use this socks server as a SOCKS5 gate / relay (i mean pass traffic thru other socks servers, especially useful when you need obtain a static connection to only one server). 
It's possible to make a simple chain like this:

> Socks client --> Our socks gate / relay server --> Any other socks5 servers

This addition is not ruining your codebase nor breaking backward API compatibility.
### Usage:

``` sh
socks.createServer(options, listener, proxOptions);
Where 'proxOptions' is object that similar to one you passing to client:
{
 enabled: true, // optional, change proxOptions.enabled to false when relay not needed anymore
 proxyHost: 'hostname or ip',
 proxyPort: 1080,
 auths: [ socks.auth.None() ]
}
```
