### PR TITLE
Return socket, even if handled

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -116,6 +116,7 @@ Server.prototype._onConnection = function(socket) {
           return socket;
         } else
           proxySocket(socket, reqInfo);
+          return socket;
       }
     }
     function deny() {
@@ -128,10 +129,11 @@ Server.prototype._onConnection = function(socket) {
 
     if (self._events.connection) {
       self.emit('connection', reqInfo, accept, deny);
-      return;
+      return socket;
     }
 
     proxySocket(socket, reqInfo);
+    return socket;
   });
 
   function onClose() {
@@ -213,7 +215,7 @@ function proxySocket(socket, req) {
            .on('connect', function() {
              connected = true;
              if (socket.writable) {
-              var localbytes = ipbytes(dstSock.localAddress || '127.0.0.1'),
+              var localbytes = ipbytes(dstSock.localAddress),
                   len = localbytes.length,
                   bufrep = new Buffer(6 + len),
                   p = 4;


### PR DESCRIPTION
A nice change to fork the socket even when it is accepted by use of the intercept flag.
