### PR TITLE
Support node 7

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,5 +1,5 @@
 var net = require('net'),
-    normalizeConnectArgs = net._normalizeConnectArgs,
+    normalizeConnectArgs = net._normalizeConnectArgs || net._normalizeArgs 
     dns = require('dns'),
     util = require('util'),
     inherits = util.inherits,


### PR DESCRIPTION
_normalizeConnectArgs is named _normalizeArgs in node >7. Use whichever is available.