### PR TITLE
Server: pass handleProxyError to connection handlers

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -125,9 +125,12 @@ Server.prototype._onConnection = function(socket) {
       if (socket.writable)
         socket.end(BUF_REP_DISALLOW);
     }
+    function error(err) {
+      handleProxyError(socket, err);
+    }
 
     if (self._events.connection) {
-      self.emit('connection', reqInfo, accept, deny);
+      self.emit('connection', reqInfo, accept, deny, error);
       return;
     }
 


### PR DESCRIPTION
Hey,

Right now, there's no way to programmatically write out an error to the underlying socket. As such, there's no good way to proxy connections manually since we can't propagate errors.

This PR provides the `handleProxyError` function to the connection event handlers.

Cheers,
Alex

