### PR TITLE
Server: handle EHOSTDOWN

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -245,6 +245,7 @@ function handleProxyError(socket, err) {
         case 'ENOTFOUND':
         case 'ETIMEDOUT':
         case 'EHOSTUNREACH':
+        case 'EHOSTDOWN':
           errbuf[1] = REP.HOSTUNREACH;
         break;
         case 'ENETUNREACH':


### PR DESCRIPTION
Hey,

connect/createConnection/Socket::connect can throw EHOSTDOWN. This ensures the `handleProxyError` function supports it and writes out `REP.HOSTUNREACH` to the client.

Cheers,
Alex